### PR TITLE
Add quote of the day frontend

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="pl">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Cytat dnia</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Lato:wght@400;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="app" aria-live="polite">
+      <section
+        class="quote-card"
+        aria-labelledby="quote-text"
+        tabindex="-1"
+      >
+        <p id="quote-text" class="quote-text">
+          Tutaj pojawi się Twój cytat dnia.
+        </p>
+        <p id="quote-date" class="quote-date" aria-live="polite"></p>
+      </section>
+      <button id="reset-button" type="button" class="reset-button">
+        Zmień arkusz
+      </button>
+      <p id="fetch-status" class="fetch-status" role="status" aria-live="polite"></p>
+    </main>
+
+    <div
+      id="setup-modal"
+      class="modal hidden"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="modal-title"
+      aria-describedby="modal-description"
+    >
+      <div class="modal-content">
+        <h2 id="modal-title">Podaj adres arkusza Google</h2>
+        <p id="modal-description">
+          Wklej adres URL eksportu CSV swojego publicznego arkusza Google, aby
+          wyświetlać codzienny cytat.
+        </p>
+        <form id="modal-form" novalidate>
+          <label class="visually-hidden" for="sheet-url"
+            >Adres CSV arkusza</label
+          >
+          <input
+            id="sheet-url"
+            name="sheet-url"
+            type="url"
+            inputmode="url"
+            autocomplete="off"
+            placeholder="https://docs.google.com/.../pub?output=csv"
+            required
+          />
+          <p id="url-error" class="url-error" role="alert" aria-live="assertive"></p>
+          <button type="submit" class="modal-submit">Zapisz</button>
+        </form>
+      </div>
+    </div>
+
+    <script src="script.js" type="module"></script>
+  </body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,524 @@
+const gradientPalettes = [
+  ['#ffecd2', '#fcb69f', '#fad0c4', '#cfd9df'],
+  ['#F5EFFF', '#E5D9F2', '#CDC1FF', '#A294F9'],
+  ['#ffdbdb', '#f4d6df', '#e9d1e3', '#decce7'],
+  ['#F08787', '#FFC7A7', '#FEE2AD', '#F8FAB4'],
+  ['#fbf1f4', '#fbe0e0', '#f2a4ab', '#c22b62'],
+  ['#e9e8ee', '#7ab7fe', '#66c1f4', '#1d6af9'],
+  ['#faf4f9', '#f5d5d4', '#ffb8ae', '#db584e'],
+  ['#f8f3ef', '#b8e797', '#90d417', '#249456']
+];
+
+const STORAGE_KEYS = {
+  sheetUrl: 'quoteSheetUrl',
+  quoteOfDay: 'quoteOfDay',
+  quoteList: 'quoteList',
+  quoteListFetchedAt: 'quoteListFetchedAt'
+};
+
+const DAY_IN_MS = 24 * 60 * 60 * 1000;
+
+const elements = {
+  quoteText: document.getElementById('quote-text'),
+  quoteDate: document.getElementById('quote-date'),
+  quoteCard: document.querySelector('.quote-card'),
+  resetButton: document.getElementById('reset-button'),
+  fetchStatus: document.getElementById('fetch-status'),
+  modal: document.getElementById('setup-modal'),
+  modalForm: document.getElementById('modal-form'),
+  sheetInput: document.getElementById('sheet-url'),
+  urlError: document.getElementById('url-error')
+};
+
+let lastFocusedElement = null;
+
+document.addEventListener('DOMContentLoaded', () => {
+  applyRandomGradient();
+  initializeModalState();
+  bindEventListeners();
+  renderStoredQuoteIfAvailable();
+
+  const sheetUrl = loadSheetUrl();
+  if (!sheetUrl) {
+    showModal();
+  } else {
+    ensureQuoteForToday();
+  }
+
+  if ('serviceWorker' in navigator) {
+    window.addEventListener('load', registerServiceWorker);
+  }
+});
+
+function initializeModalState() {
+  if (elements.modal) {
+    elements.modal.setAttribute('aria-hidden', 'true');
+  }
+}
+
+function bindEventListeners() {
+  if (elements.modalForm) {
+    elements.modalForm.addEventListener('submit', handleModalSubmit);
+  }
+
+  if (elements.resetButton) {
+    elements.resetButton.addEventListener('click', handleReset);
+  }
+
+  if (elements.modal) {
+    elements.modal.addEventListener('keydown', trapModalFocus);
+  }
+}
+
+function renderStoredQuoteIfAvailable() {
+  const storedQuote = loadStoredQuoteOfDay();
+  if (storedQuote && storedQuote.text) {
+    renderQuote(storedQuote.text, storedQuote.date);
+  } else {
+    renderQuote('', '');
+  }
+}
+
+function applyRandomGradient() {
+  const palette =
+    gradientPalettes[Math.floor(Math.random() * gradientPalettes.length)];
+  const gradients = [
+    `radial-gradient(circle at top left, ${palette[0]} 0%, transparent 60%)`,
+    `radial-gradient(circle at top right, ${palette[1]} 0%, transparent 60%)`,
+    `radial-gradient(circle at bottom left, ${palette[2]} 0%, transparent 60%)`,
+    `radial-gradient(circle at bottom right, ${palette[3]} 0%, transparent 60%)`
+  ];
+
+  document.body.style.background = gradients.join(', ');
+  document.body.style.backgroundColor = blendAverageColor(palette);
+  document.body.style.backgroundRepeat = 'no-repeat';
+  document.body.style.backgroundAttachment = 'fixed';
+
+  const avgColor = blendAverageColor(palette);
+  const brightness = perceivedBrightness(hexToRgb(avgColor));
+  const textColor = brightness > 0.6 ? '#1a1a1a' : '#ffffff';
+  document.documentElement.style.setProperty('--quote-color', textColor);
+
+  if (textColor === '#ffffff') {
+    document.documentElement.style.setProperty(
+      '--card-backdrop',
+      'rgba(0, 0, 0, 0.35)'
+    );
+    document.documentElement.style.setProperty(
+      '--card-shadow',
+      '0 20px 45px rgba(0, 0, 0, 0.35)'
+    );
+  } else {
+    document.documentElement.style.setProperty(
+      '--card-backdrop',
+      'rgba(255, 255, 255, 0.4)'
+    );
+    document.documentElement.style.setProperty(
+      '--card-shadow',
+      '0 20px 45px rgba(0, 0, 0, 0.15)'
+    );
+  }
+}
+
+function hexToRgb(hex) {
+  const sanitized = hex.replace('#', '');
+  const normalized =
+    sanitized.length === 3
+      ? sanitized
+          .split('')
+          .map((char) => char + char)
+          .join('')
+      : sanitized;
+  const bigint = parseInt(normalized, 16);
+  return {
+    r: (bigint >> 16) & 255,
+    g: (bigint >> 8) & 255,
+    b: bigint & 255
+  };
+}
+
+function perceivedBrightness({ r, g, b }) {
+  return (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+}
+
+function blendAverageColor(palette) {
+  const totals = palette.reduce(
+    (acc, color) => {
+      const { r, g, b } = hexToRgb(color);
+      acc.r += r;
+      acc.g += g;
+      acc.b += b;
+      return acc;
+    },
+    { r: 0, g: 0, b: 0 }
+  );
+  const avg = {
+    r: Math.round(totals.r / palette.length),
+    g: Math.round(totals.g / palette.length),
+    b: Math.round(totals.b / palette.length)
+  };
+  return rgbToHex(avg);
+}
+
+function rgbToHex({ r, g, b }) {
+  const toHex = (value) => value.toString(16).padStart(2, '0');
+  return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+}
+
+function handleModalSubmit(event) {
+  event.preventDefault();
+  clearModalError();
+  const rawValue = elements.sheetInput.value.trim();
+
+  if (!rawValue) {
+    displayModalError('Adres URL jest wymagany.');
+    return;
+  }
+
+  try {
+    const sanitizedUrl = sanitizeSheetUrl(rawValue);
+    localStorage.setItem(STORAGE_KEYS.sheetUrl, sanitizedUrl);
+    hideModal();
+    setFetchStatus('Pobieranie cytatów…');
+    ensureQuoteForToday();
+  } catch (error) {
+    displayModalError(error.message || 'Podano nieprawidłowy adres URL.');
+  }
+}
+
+function sanitizeSheetUrl(value) {
+  let url;
+  try {
+    url = new URL(value);
+  } catch (error) {
+    throw new Error('Podaj poprawny adres URL.');
+  }
+
+  if (url.protocol !== 'https:') {
+    throw new Error('Adres musi zaczynać się od https://');
+  }
+
+  if (url.hostname !== 'docs.google.com') {
+    throw new Error('Adres musi wskazywać na docs.google.com');
+  }
+
+  return url.toString();
+}
+
+function displayModalError(message) {
+  if (elements.urlError) {
+    elements.urlError.textContent = message;
+  }
+}
+
+function clearModalError() {
+  if (elements.urlError) {
+    elements.urlError.textContent = '';
+  }
+}
+
+function showModal() {
+  if (!elements.modal) return;
+  lastFocusedElement = document.activeElement;
+  elements.modal.classList.remove('hidden');
+  elements.modal.setAttribute('aria-hidden', 'false');
+  document.body.classList.add('modal-open');
+  elements.sheetInput.value = loadSheetUrl() || '';
+  clearModalError();
+  requestAnimationFrame(() => {
+    elements.sheetInput.focus();
+    elements.sheetInput.select();
+  });
+}
+
+function hideModal() {
+  if (!elements.modal) return;
+  elements.modal.classList.add('hidden');
+  elements.modal.setAttribute('aria-hidden', 'true');
+  document.body.classList.remove('modal-open');
+  if (lastFocusedElement && typeof lastFocusedElement.focus === 'function') {
+    lastFocusedElement.focus();
+  } else if (elements.quoteCard) {
+    elements.quoteCard.focus();
+  }
+  lastFocusedElement = null;
+}
+
+function trapModalFocus(event) {
+  if (event.key === 'Escape') {
+    event.preventDefault();
+    event.stopPropagation();
+  }
+
+  if (event.key !== 'Tab') {
+    return;
+  }
+
+  const focusableSelectors =
+    'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])';
+  const focusableElements = Array.from(
+    elements.modal.querySelectorAll(focusableSelectors)
+  ).filter((el) => !el.hasAttribute('disabled'));
+
+  if (!focusableElements.length) {
+    event.preventDefault();
+    return;
+  }
+
+  const firstElement = focusableElements[0];
+  const lastElement = focusableElements[focusableElements.length - 1];
+
+  if (!event.shiftKey && document.activeElement === lastElement) {
+    event.preventDefault();
+    firstElement.focus();
+  } else if (event.shiftKey && document.activeElement === firstElement) {
+    event.preventDefault();
+    lastElement.focus();
+  }
+}
+
+function handleReset() {
+  Object.values(STORAGE_KEYS).forEach((key) => localStorage.removeItem(key));
+  renderQuote('', '');
+  setFetchStatus('Podaj nowy adres arkusza, aby kontynuować.');
+  showModal();
+}
+
+function setFetchStatus(message, isError = false) {
+  if (!elements.fetchStatus) return;
+  elements.fetchStatus.textContent = message || '';
+  elements.fetchStatus.classList.toggle('is-error', Boolean(isError));
+}
+
+function loadSheetUrl() {
+  return localStorage.getItem(STORAGE_KEYS.sheetUrl);
+}
+
+function loadStoredQuoteOfDay() {
+  const raw = localStorage.getItem(STORAGE_KEYS.quoteOfDay);
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed.text === 'string' && parsed.date) {
+      return parsed;
+    }
+  } catch (error) {
+    console.warn('Nie można odczytać zapisanego cytatu dnia.', error);
+  }
+  return null;
+}
+
+function saveQuoteOfDay(value) {
+  localStorage.setItem(STORAGE_KEYS.quoteOfDay, JSON.stringify(value));
+}
+
+function loadStoredQuoteList() {
+  const raw = localStorage.getItem(STORAGE_KEYS.quoteList);
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : null;
+  } catch (error) {
+    console.warn('Nie można odczytać zapisanej listy cytatów.', error);
+    return null;
+  }
+}
+
+function saveQuoteList(list) {
+  localStorage.setItem(STORAGE_KEYS.quoteList, JSON.stringify(list));
+  localStorage.setItem(STORAGE_KEYS.quoteListFetchedAt, new Date().toISOString());
+}
+
+function shouldFetchQuotes(lastFetchedAt) {
+  if (!lastFetchedAt) return true;
+  const lastFetchedDate = new Date(lastFetchedAt);
+  if (Number.isNaN(lastFetchedDate.getTime())) {
+    return true;
+  }
+  return Date.now() - lastFetchedDate.getTime() > DAY_IN_MS;
+}
+
+async function ensureQuoteForToday() {
+  const sheetUrl = loadSheetUrl();
+  if (!sheetUrl) {
+    showModal();
+    return;
+  }
+
+  let quoteOfDay = loadStoredQuoteOfDay();
+  const todayKey = getTodayKey();
+
+  let quoteList = loadStoredQuoteList();
+  const lastFetchedAt = localStorage.getItem(STORAGE_KEYS.quoteListFetchedAt);
+  const needsFetch =
+    !quoteList || !quoteList.length || shouldFetchQuotes(lastFetchedAt);
+
+  if (needsFetch) {
+    try {
+      setFetchStatus('Pobieranie nowych cytatów…');
+      const fetchedQuotes = await fetchQuotes(sheetUrl);
+      if (fetchedQuotes.length) {
+        quoteList = fetchedQuotes;
+        saveQuoteList(fetchedQuotes);
+        setFetchStatus('');
+      } else {
+        setFetchStatus('W arkuszu nie znaleziono cytatów.', true);
+      }
+    } catch (error) {
+      console.error('Błąd pobierania arkusza Google.', error);
+      setFetchStatus(
+        'Nie udało się pobrać nowych cytatów. Wyświetlam ostatnio zapisane.',
+        true
+      );
+      quoteList = loadStoredQuoteList() || quoteList;
+    }
+  }
+
+  if (quoteOfDay && quoteOfDay.text && quoteOfDay.date === todayKey) {
+    renderQuote(quoteOfDay.text, quoteOfDay.date);
+    return;
+  }
+
+  if (!quoteList || !quoteList.length) {
+    if (quoteOfDay && quoteOfDay.text) {
+      renderQuote(quoteOfDay.text, quoteOfDay.date);
+    } else {
+      renderQuote(
+        'Brak cytatów do wyświetlenia. Upewnij się, że arkusz zawiera dane.',
+        ''
+      );
+    }
+    return;
+  }
+
+  const newQuote = pickQuoteForToday(quoteList);
+  quoteOfDay = {
+    date: todayKey,
+    text: newQuote
+  };
+  saveQuoteOfDay(quoteOfDay);
+  renderQuote(newQuote, todayKey);
+}
+
+async function fetchQuotes(sheetUrl) {
+  const response = await fetch(sheetUrl, { cache: 'no-store' });
+  if (!response.ok) {
+    throw new Error(`Nie udało się pobrać arkusza (status ${response.status}).`);
+  }
+  const csvText = await response.text();
+  const quotes = parseCsvQuotes(csvText);
+  if (!quotes.length) {
+    console.warn('Nie znaleziono cytatów w podanym arkuszu.');
+  }
+  return quotes;
+}
+
+function parseCsvQuotes(csvText) {
+  const cleanText = csvText.replace(/^\uFEFF/, '');
+  const lines = cleanText.split(/\r?\n/);
+  if (!lines.length) return [];
+  const dataLines = lines.slice(1);
+  const quotes = [];
+
+  for (const rawLine of dataLines) {
+    if (!rawLine || !rawLine.trim()) continue;
+    const cells = splitCsvLine(rawLine);
+    const firstNonEmpty = cells.find((cell) => cell.trim() !== '');
+    if (!firstNonEmpty) continue;
+    const sanitized = firstNonEmpty
+      .replace(/^"|"$/g, '')
+      .replace(/""/g, '"')
+      .trim();
+    if (sanitized) {
+      quotes.push(sanitized);
+    }
+  }
+
+  return quotes;
+}
+
+function splitCsvLine(line) {
+  const cells = [];
+  let current = '';
+  let inQuotes = false;
+
+  for (let i = 0; i < line.length; i += 1) {
+    const char = line[i];
+
+    if (char === '"') {
+      if (inQuotes && line[i + 1] === '"') {
+        current += '"';
+        i += 1;
+      } else {
+        inQuotes = !inQuotes;
+      }
+      continue;
+    }
+
+    if (char === ',' && !inQuotes) {
+      cells.push(current);
+      current = '';
+      continue;
+    }
+
+    current += char;
+  }
+  cells.push(current);
+  return cells;
+}
+
+function pickQuoteForToday(quotes) {
+  if (!quotes.length) return '';
+  const index = Math.floor(Math.random() * quotes.length);
+  return quotes[index];
+}
+
+function renderQuote(text, dateKey) {
+  const cleanedText = typeof text === 'string' ? text.trim() : '';
+  if (!cleanedText) {
+    elements.quoteText.textContent = 'Tutaj pojawi się Twój cytat dnia.';
+    elements.quoteDate.textContent = '';
+    return;
+  }
+
+  elements.quoteText.textContent = cleanedText;
+
+  if (!dateKey) {
+    elements.quoteDate.textContent = '';
+    return;
+  }
+
+  const formattedDate = formatDateLabel(dateKey);
+  if (formattedDate) {
+    const label =
+      dateKey === getTodayKey()
+        ? `Cytat dnia — ${formattedDate}`
+        : `Ostatnio zapisany cytat — ${formattedDate}`;
+    elements.quoteDate.textContent = label;
+  } else {
+    elements.quoteDate.textContent = '';
+  }
+}
+
+function formatDateLabel(dateKey) {
+  if (!dateKey) return '';
+  const date = new Date(`${dateKey}T00:00:00`);
+  if (Number.isNaN(date.getTime())) return '';
+  return new Intl.DateTimeFormat('pl-PL', {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric'
+  }).format(date);
+}
+
+function getTodayKey() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+async function registerServiceWorker() {
+  try {
+    await navigator.serviceWorker.register('./service-worker.js');
+  } catch (error) {
+    console.warn('Nie udało się zarejestrować Service Workera.', error);
+  }
+}

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,63 @@
+const CACHE_NAME = 'quote-of-the-day-v1';
+const PRECACHE_URLS = [
+  './',
+  './index.html',
+  './styles.css',
+  './script.js',
+  'https://fonts.googleapis.com/css2?family=Lato:wght@400;700&display=swap'
+];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(PRECACHE_URLS))
+  );
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches
+      .keys()
+      .then((keys) =>
+        Promise.all(keys.filter((key) => key !== CACHE_NAME).map((key) => caches.delete(key)))
+      )
+  );
+  self.clients.claim();
+});
+
+self.addEventListener('fetch', (event) => {
+  const { request } = event;
+  const url = new URL(request.url);
+
+  if (url.origin !== self.location.origin) {
+    return;
+  }
+
+  if (request.mode === 'navigate') {
+    event.respondWith(
+      fetch(request)
+        .then((response) => {
+          const responseClone = response.clone();
+          caches.open(CACHE_NAME).then((cache) => cache.put(request, responseClone));
+          return response;
+        })
+        .catch(() => caches.match('./index.html'))
+    );
+    return;
+  }
+
+  event.respondWith(
+    caches.match(request).then((cached) => {
+      if (cached) {
+        return cached;
+      }
+      return fetch(request)
+        .then((response) => {
+          const responseClone = response.clone();
+          caches.open(CACHE_NAME).then((cache) => cache.put(request, responseClone));
+          return response;
+        })
+        .catch(() => cached);
+    })
+  );
+});

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,238 @@
+:root {
+  --quote-color: #1a1a1a;
+  --card-backdrop: rgba(255, 255, 255, 0.4);
+  --card-shadow: 0 20px 45px rgba(0, 0, 0, 0.15);
+  --modal-overlay: rgba(0, 0, 0, 0.35);
+  --font-family: 'Lato', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: var(--font-family);
+  min-height: 100vh;
+  color: var(--quote-color);
+  display: flex;
+  align-items: stretch;
+}
+
+main.app {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  min-height: 100vh;
+  padding: clamp(2rem, 4vw, 4rem);
+  position: relative;
+}
+
+.quote-card {
+  max-width: min(70ch, 100%);
+  background: var(--card-backdrop);
+  backdrop-filter: blur(12px);
+  border-radius: 24px;
+  padding: clamp(2rem, 5vw, 4rem);
+  box-shadow: var(--card-shadow);
+  transition: transform 0.6s ease, box-shadow 0.6s ease;
+}
+
+.quote-card:hover,
+.quote-card:focus-within {
+  transform: translateY(-4px);
+  box-shadow: 0 28px 60px rgba(0, 0, 0, 0.2);
+}
+
+.quote-text {
+  font-size: clamp(2rem, 4vw, 4rem);
+  line-height: 1.4;
+  margin: 0;
+  font-weight: 700;
+}
+
+.quote-date {
+  margin-top: clamp(1rem, 3vw, 2rem);
+  font-size: clamp(1rem, 2vw, 1.4rem);
+  font-weight: 400;
+  letter-spacing: 0.02em;
+}
+
+.reset-button {
+  position: fixed;
+  right: clamp(1rem, 3vw, 2rem);
+  bottom: clamp(1rem, 3vw, 2rem);
+  border: none;
+  border-radius: 999px;
+  padding: 0.6rem 1.1rem;
+  font-size: 0.95rem;
+  background: rgba(0, 0, 0, 0.4);
+  color: #fff;
+  cursor: pointer;
+  backdrop-filter: blur(8px);
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.2);
+  transition: transform 0.3s ease, box-shadow 0.3s ease, background 0.3s ease;
+}
+
+.reset-button:hover,
+.reset-button:focus {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 38px rgba(0, 0, 0, 0.25);
+  outline: none;
+  background: rgba(0, 0, 0, 0.6);
+}
+
+.reset-button:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.8);
+  outline-offset: 4px;
+}
+
+.fetch-status {
+  position: fixed;
+  right: clamp(1rem, 3vw, 2rem);
+  bottom: calc(clamp(1rem, 3vw, 2rem) + 3.2rem);
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--quote-color);
+  max-width: 18rem;
+  text-align: right;
+  text-shadow: 0 1px 2px rgba(255, 255, 255, 0.4);
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(
+      115deg,
+      rgba(255, 255, 255, 0.2),
+      rgba(0, 0, 0, 0.35)
+    ),
+    var(--modal-overlay);
+  backdrop-filter: blur(8px);
+  transition: opacity 0.3s ease;
+  z-index: 10;
+}
+
+.modal.hidden {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.modal-content {
+  width: min(90vw, 420px);
+  background: rgba(255, 255, 255, 0.85);
+  border-radius: 24px;
+  padding: 2.5rem 2rem;
+  box-shadow: 0 20px 45px rgba(0, 0, 0, 0.2);
+  text-align: center;
+}
+
+.modal-content h2 {
+  margin: 0 0 0.75rem;
+  font-size: 1.6rem;
+  color: #1a1a1a;
+}
+
+.modal-content p {
+  margin: 0 0 1.5rem;
+  color: #333;
+  font-size: 1rem;
+}
+
+#modal-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+#sheet-url {
+  padding: 0.85rem 1rem;
+  border-radius: 999px;
+  border: 2px solid rgba(26, 26, 26, 0.2);
+  font-size: 1rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+#sheet-url:focus {
+  outline: none;
+  border-color: #1a1a1a;
+  box-shadow: 0 0 0 4px rgba(26, 26, 26, 0.2);
+}
+
+.modal-submit {
+  padding: 0.9rem;
+  border: none;
+  border-radius: 999px;
+  background: #1a1a1a;
+  color: #fff;
+  font-size: 1rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 0.25s ease, box-shadow 0.25s ease, background 0.25s ease;
+}
+
+.modal-submit:hover,
+.modal-submit:focus {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.2);
+  outline: none;
+}
+
+.modal-submit:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.9);
+  outline-offset: 3px;
+}
+
+.url-error {
+  min-height: 1.2rem;
+  font-size: 0.9rem;
+  color: #b00020;
+  margin: 0;
+}
+
+body.modal-open {
+  overflow: hidden;
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (max-width: 600px) {
+  .quote-card {
+    padding: clamp(1.5rem, 6vw, 2.5rem);
+  }
+
+  .fetch-status {
+    left: 50%;
+    bottom: auto;
+    top: clamp(1rem, 4vw, 3rem);
+    transform: translateX(-50%);
+    text-align: center;
+  }
+
+  .reset-button {
+    right: 50%;
+    transform: translateX(50%);
+  }
+}
+
+.fetch-status.is-error {
+  color: #b00020;
+  text-shadow: none;
+}


### PR DESCRIPTION
## Summary
- implement a standalone quote-of-the-day page that loads user-provided Google Sheet CSVs
- add gradient styling, modal onboarding, and localStorage caching for daily quotes
- register a service worker that precaches core assets for offline-ready behavior

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d2c761863c832b8e9e1b077a07f554