### PR TITLE
Add tutorial video embed to setup modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,34 +50,49 @@
       aria-labelledby="modal-title"
       aria-describedby="modal-description"
     >
-      <div class="modal-content">
-        <h2 id="modal-title">Podaj adres arkusza Google</h2>
-        <p id="modal-description">
-          Wklej adres URL eksportu CSV swojego publicznego arkusza Google, aby
-          wyświetlać codzienny cytat.
-        </p>
-        <form id="modal-form" novalidate>
-          <label class="visually-hidden" for="sheet-url"
-            >Adres CSV arkusza</label
-          >
-          <input
-            id="sheet-url"
-            name="sheet-url"
-            type="url"
-            inputmode="url"
-            autocomplete="off"
-            placeholder="https://docs.google.com/.../pub?output=csv"
-            aria-describedby="privacy-note url-error"
-            required
-          />
-          <p id="privacy-note" class="modal-privacy-note">
-            „Maksymalna prywatność. Nie tworzymy kont, nie zbieramy danych.
-            Twoje treści zostają tylko na Twoim komputerze – nic nie trafia na
-            serwer ani do chmury.”
+      <div class="modal-container">
+        <aside class="modal-video" aria-label="Instrukcja wideo">
+          <div class="modal-video__wrapper">
+            <iframe
+              src="https://www.youtube.com/embed/WPvG8sPFEvo"
+              title="Jak przygotować i wkleić plik CSV"
+              frameborder="0"
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+              referrerpolicy="strict-origin-when-cross-origin"
+              allowfullscreen
+            ></iframe>
+          </div>
+          <p class="modal-video__caption">Zobacz, jak stworzyć i wkleić swój arkusz.</p>
+        </aside>
+        <div class="modal-content">
+          <h2 id="modal-title">Podaj adres arkusza Google</h2>
+          <p id="modal-description">
+            Wklej adres URL eksportu CSV swojego publicznego arkusza Google, aby
+            wyświetlać codzienny cytat.
           </p>
-          <p id="url-error" class="url-error" role="alert" aria-live="assertive"></p>
-          <button type="submit" class="modal-submit">Zapisz</button>
-        </form>
+          <form id="modal-form" novalidate>
+            <label class="visually-hidden" for="sheet-url"
+              >Adres CSV arkusza</label
+            >
+            <input
+              id="sheet-url"
+              name="sheet-url"
+              type="url"
+              inputmode="url"
+              autocomplete="off"
+              placeholder="https://docs.google.com/.../pub?output=csv"
+              aria-describedby="privacy-note url-error"
+              required
+            />
+            <p id="privacy-note" class="modal-privacy-note">
+              „Maksymalna prywatność. Nie tworzymy kont, nie zbieramy danych.
+              Twoje treści zostają tylko na Twoim komputerze – nic nie trafia na
+              serwer ani do chmury.”
+            </p>
+            <p id="url-error" class="url-error" role="alert" aria-live="assertive"></p>
+            <button type="submit" class="modal-submit">Zapisz</button>
+          </form>
+        </div>
       </div>
     </div>
 

--- a/styles.css
+++ b/styles.css
@@ -181,8 +181,54 @@ main.app {
   pointer-events: none;
 }
 
+.modal-container {
+  display: flex;
+  gap: clamp(1.5rem, 3vw, 2.5rem);
+  align-items: stretch;
+  width: min(90vw, 920px);
+}
+
+.modal-video {
+  flex: 1 1 320px;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.65);
+  border-radius: 24px;
+  padding: 1.5rem;
+  box-shadow: 0 16px 36px rgba(0, 0, 0, 0.18);
+  text-align: left;
+}
+
+.modal-video__wrapper {
+  position: relative;
+  width: 100%;
+  padding-top: 56.25%;
+  border-radius: 16px;
+  overflow: hidden;
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.2);
+  margin-bottom: 1rem;
+}
+
+.modal-video iframe {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+  border-radius: 16px;
+}
+
+.modal-video__caption {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #1a1a1a;
+  line-height: 1.4;
+}
+
 .modal-content {
-  width: min(90vw, 420px);
+  flex: 1 1 360px;
   background: rgba(255, 255, 255, 0.85);
   border-radius: 24px;
   padding: 2.5rem 2rem;
@@ -279,6 +325,21 @@ body.modal-open {
 @media (max-width: 600px) {
   .quote-card {
     padding: clamp(1.5rem, 6vw, 2.5rem);
+  }
+
+  .modal-container {
+    flex-direction: column;
+    width: min(94vw, 520px);
+  }
+
+  .modal-video,
+  .modal-content {
+    padding: 1.75rem 1.5rem;
+    text-align: center;
+  }
+
+  .modal-video__caption {
+    font-size: 0.9rem;
   }
 
   .fetch-status {


### PR DESCRIPTION
## Summary
- embed the CSV tutorial video alongside the setup modal
- style the modal layout to present the video on the left with responsive stacking on small screens

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d51a7257b4832bbeb4ef95fb06acd9