### PR TITLE
Adjust setup modal layout for CSV onboarding

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,7 +62,6 @@
               allowfullscreen
             ></iframe>
           </div>
-          <p class="modal-video__caption">Zobacz, jak stworzyć i wkleić swój arkusz.</p>
         </aside>
         <div class="modal-content">
           <h2 id="modal-title">Podaj adres arkusza Google</h2>

--- a/styles.css
+++ b/styles.css
@@ -184,51 +184,33 @@ main.app {
 .modal-container {
   display: flex;
   gap: clamp(1.5rem, 3vw, 2.5rem);
-  align-items: stretch;
-  width: min(90vw, 920px);
+  align-items: center;
+  justify-content: center;
+  width: min(90vw, 1200px);
 }
 
 .modal-video {
-  flex: 1 1 320px;
+  flex: 2 1 60%;
   display: flex;
-  flex-direction: column;
-  align-items: stretch;
+  align-items: center;
   justify-content: center;
-  background: rgba(255, 255, 255, 0.65);
-  border-radius: 24px;
-  padding: 1.5rem;
-  box-shadow: 0 16px 36px rgba(0, 0, 0, 0.18);
-  text-align: left;
 }
 
 .modal-video__wrapper {
-  position: relative;
   width: 100%;
-  padding-top: 56.25%;
-  border-radius: 16px;
-  overflow: hidden;
-  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.2);
-  margin-bottom: 1rem;
+  aspect-ratio: 16 / 9;
 }
 
 .modal-video iframe {
-  position: absolute;
-  inset: 0;
   width: 100%;
   height: 100%;
   border: 0;
-  border-radius: 16px;
-}
-
-.modal-video__caption {
-  margin: 0;
-  font-size: 0.95rem;
-  color: #1a1a1a;
-  line-height: 1.4;
+  display: block;
 }
 
 .modal-content {
-  flex: 1 1 360px;
+  flex: 1 1 40%;
+  max-width: 420px;
   background: rgba(255, 255, 255, 0.85);
   border-radius: 24px;
   padding: 2.5rem 2rem;
@@ -330,16 +312,12 @@ body.modal-open {
   .modal-container {
     flex-direction: column;
     width: min(94vw, 520px);
+    align-items: stretch;
   }
 
   .modal-video,
   .modal-content {
-    padding: 1.75rem 1.5rem;
-    text-align: center;
-  }
-
-  .modal-video__caption {
-    font-size: 0.9rem;
+    width: 100%;
   }
 
   .fetch-status {


### PR DESCRIPTION
## Summary
- center the setup modal contents and size the YouTube player to take two thirds of the width beside the form
- remove the extra framing around the embedded video so only the player is visible

## Testing
- not run (static assets only)


------
https://chatgpt.com/codex/tasks/task_e_68d522941f7c832b8a5d04059229068a