### PR TITLE
Adjust modal privacy note text and size

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,9 +84,9 @@
               required
             />
             <p id="privacy-note" class="modal-privacy-note">
-              „Maksymalna prywatność. Nie tworzymy kont, nie zbieramy danych.
+              Maksymalna prywatność. Nie tworzymy kont, nie zbieramy danych.
               Twoje treści zostają tylko na Twoim komputerze – nic nie trafia na
-              serwer ani do chmury.”
+              serwer ani do chmury.
             </p>
             <p id="url-error" class="url-error" role="alert" aria-live="assertive"></p>
             <button type="submit" class="modal-submit">Zapisz</button>

--- a/styles.css
+++ b/styles.css
@@ -253,8 +253,8 @@ main.app {
 .modal-privacy-note {
   margin: -0.25rem 0 0;
   color: #4a4a4a;
-  font-size: 0.85rem;
-  line-height: 1.5;
+  font-size: 0.75rem;
+  line-height: 1.4;
 }
 
 .modal-submit {


### PR DESCRIPTION
## Summary
- update the modal privacy note copy to remove decorative quotes and match the requested wording
- decrease the privacy note font size so the paragraph fits on two lines inside the modal

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d528c7a81c832ba721ed19a1ffe351